### PR TITLE
Mimetype

### DIFF
--- a/mcomix/mcomix/archive_tools.py
+++ b/mcomix/mcomix/archive_tools.py
@@ -70,16 +70,6 @@ _HANDLERS = {
     ),
 }
 
-def _getext(path):
-    ''' Get extension of archive '''
-    compressed_ext=('.gz','.bz2','.bz','.lzma','.xz')
-    b,e=os.path.splitext(path.lower())
-    if e in compressed_ext:
-        b,e2=os.path.splitext(b)
-        if e2=='.tar':
-            e=e2+e
-    return e
-
 def _get_handler(archive_type):
     ''' Return best archive class for format <archive_type> '''
 
@@ -138,7 +128,7 @@ def get_supported_formats():
 def is_archive_file(path):
     if not SUPPORTED_ARCHIVE_FORMATS:
         init_supported_formats()
-    return _getext(path) in SUPPORTED_ARCHIVE_EXTS
+    return path.lower().endswith(tuple(SUPPORTED_ARCHIVE_EXTS))
 
 def archive_mime_type(path):
     '''Return the archive type of <path> or None for non-archives.'''

--- a/mcomix/mcomix/file_provider.py
+++ b/mcomix/mcomix/file_provider.py
@@ -2,6 +2,7 @@
 ''' file_provider.py - Handles listing files for the current directory and
     switching to the next/previous directory. '''
 
+import functools
 import os
 import re
 
@@ -113,7 +114,8 @@ class OrderedFileProvider(FileProvider):
             Returns a list of absolute paths, already sorted. '''
 
         if mode == FileProvider.IMAGES:
-            should_accept = image_tools.is_image_file
+            should_accept = functools.partial(
+                image_tools.is_image_file, check_mimetype=True)
         elif mode == FileProvider.ARCHIVES:
             should_accept = archive_tools.is_archive_file
         else:

--- a/mcomix/mcomix/image_tools.py
+++ b/mcomix/mcomix/image_tools.py
@@ -631,7 +631,7 @@ def is_image_file(path, check_mimetype=False):
     # to guess if path is supported, ignoring file extension.
     if not SUPPORTED_IMAGE_FORMATS:
         init_supported_formats()
-    if check_mimetype:
+    if check_mimetype and os.path.isfile(path):
         with open(path, mode='rb') as fd:
             magic = fd.read(10)
         mime, uncertain = Gio.content_type_guess(data=magic)

--- a/mcomix/mcomix/image_tools.py
+++ b/mcomix/mcomix/image_tools.py
@@ -603,8 +603,8 @@ def init_supported_formats():
 
     # formats supported by gdk-pixbuf
     for gdkfmt in GdkPixbuf.Pixbuf.get_formats():
-        fmt=SUPPORTED_IMAGE_FORMATS.setdefault(gdkfmt.get_name().upper(),
-                                               (set(),set()))
+        fmt=SUPPORTED_IMAGE_FORMATS.setdefault(
+            gdkfmt.get_name().upper(),(set(),set()))
         for m in map(lambda s:s.lower(),gdkfmt.get_mime_types()):
             fmt[0].add(m)
         # get_extensions() return extensions without '.'

--- a/mcomix/mcomix/image_tools.py
+++ b/mcomix/mcomix/image_tools.py
@@ -8,7 +8,7 @@ import re
 import sys
 import operator
 
-from gi.repository import GdkPixbuf, Gdk, GLib, Gtk
+from gi.repository import GdkPixbuf, Gdk, Gio, GLib, Gtk
 from PIL import Image
 from PIL import ImageEnhance
 from PIL import ImageOps
@@ -586,7 +586,7 @@ def get_image_info(path):
         info = (_('Unknown filetype'), 0, 0)
     return info
 
-SUPPORTED_IMAGE_EXTS=[]
+SUPPORTED_IMAGE_EXTS=set()
 SUPPORTED_IMAGE_FORMATS={}
 
 def init_supported_formats():
@@ -594,28 +594,29 @@ def init_supported_formats():
     # Make sure all supported formats are registered.
     Image.init()
     for ext,name in Image.EXTENSION.items():
-        fmt=SUPPORTED_IMAGE_FORMATS.setdefault(name,([],[]))
-        fmt[1].append(ext.lower())
-        if name not in Image.MIME:
-            continue
-        mime=Image.MIME[name].lower()
-        if mime not in fmt[0]:
-            fmt[0].append(mime)
+        fmt=SUPPORTED_IMAGE_FORMATS.setdefault(name,(set(),set()))
+        fmt[1].add(ext.lower())
+        mime=Image.MIME.get(
+            name, Gio.content_type_guess(filename='file'+ext)[0]).lower()
+        if mime and mime != 'application/octet-stream':
+            fmt[0].add(mime)
 
     # formats supported by gdk-pixbuf
     for gdkfmt in GdkPixbuf.Pixbuf.get_formats():
-        fmt=SUPPORTED_IMAGE_FORMATS.setdefault(gdkfmt.get_name().upper(),([],[]))
+        fmt=SUPPORTED_IMAGE_FORMATS.setdefault(gdkfmt.get_name().upper(),
+                                               (set(),set()))
         for m in map(lambda s:s.lower(),gdkfmt.get_mime_types()):
-            if m not in fmt[0]:
-                fmt[0].append(m)
+            fmt[0].add(m)
         # get_extensions() return extensions without '.'
         for e in map(lambda s:'.'+s.lower(),gdkfmt.get_extensions()):
-            if e not in fmt[1]:
-                fmt[1].append(e)
+            fmt[1].add(e)
+            m = Gio.content_type_guess(filename='file'+e)[0].lower()
+            if m and m != 'application/octet-stream':
+                fmt[0].add(m)
 
     # cache a supported extensions list
     for mimes,exts in SUPPORTED_IMAGE_FORMATS.values():
-        SUPPORTED_IMAGE_EXTS.extend(exts)
+        SUPPORTED_IMAGE_EXTS.update(exts)
 
 def get_supported_formats():
     if not SUPPORTED_IMAGE_FORMATS:

--- a/mcomix/mcomix/image_tools.py
+++ b/mcomix/mcomix/image_tools.py
@@ -631,7 +631,7 @@ def is_image_file(path, check_mimetype=False):
     # to guess if path is supported, ignoring file extension.
     if not SUPPORTED_IMAGE_FORMATS:
         init_supported_formats()
-    if check_mimetype and os.path.isfile(path):
+    if prefs['check image mimetype'] and check_mimetype and os.path.isfile(path):
         with open(path, mode='rb') as fd:
             magic = fd.read(10)
         mime, uncertain = Gio.content_type_guess(data=magic)

--- a/mcomix/mcomix/image_tools.py
+++ b/mcomix/mcomix/image_tools.py
@@ -626,6 +626,6 @@ def get_supported_formats():
 def is_image_file(path):
     if not SUPPORTED_IMAGE_FORMATS:
         init_supported_formats()
-    return os.path.splitext(path)[1].lower() in SUPPORTED_IMAGE_EXTS
+    return path.lower().endswith(tuple(SUPPORTED_IMAGE_EXTS))
 
 # vim: expandtab:sw=4:ts=4

--- a/mcomix/mcomix/image_tools.py
+++ b/mcomix/mcomix/image_tools.py
@@ -587,6 +587,7 @@ def get_image_info(path):
     return info
 
 SUPPORTED_IMAGE_EXTS=set()
+SUPPORTED_IMAGE_MIMES=set()
 SUPPORTED_IMAGE_FORMATS={}
 
 def init_supported_formats():
@@ -617,15 +618,24 @@ def init_supported_formats():
     # cache a supported extensions list
     for mimes,exts in SUPPORTED_IMAGE_FORMATS.values():
         SUPPORTED_IMAGE_EXTS.update(exts)
+        SUPPORTED_IMAGE_MIMES.update(mimes)
 
 def get_supported_formats():
     if not SUPPORTED_IMAGE_FORMATS:
         init_supported_formats()
     return SUPPORTED_IMAGE_FORMATS
 
-def is_image_file(path):
+def is_image_file(path, check_mimetype=False):
+    # if check_mimetype is True,
+    # read starting bytes and using Gio.content_type_guess
+    # to guess if path is supported, ignoring file extension.
     if not SUPPORTED_IMAGE_FORMATS:
         init_supported_formats()
+    if check_mimetype:
+        with open(path, mode='rb') as fd:
+            magic = fd.read(10)
+        mime, uncertain = Gio.content_type_guess(data=magic)
+        return mime.lower() in SUPPORTED_IMAGE_MIMES
     return path.lower().endswith(tuple(SUPPORTED_IMAGE_EXTS))
 
 # vim: expandtab:sw=4:ts=4

--- a/mcomix/mcomix/preferences.py
+++ b/mcomix/mcomix/preferences.py
@@ -113,6 +113,7 @@ prefs = {
     'osd timeout': 3.0,  # in seconds, hard limited from 0.5 to 30.0
     'userstyle': None,  # None to disable userstyle
     'mount': False,
+    'check image mimetype': False,
 }
 
 def read_preferences_file():

--- a/mcomix/mcomix/preferences_dialog.py
+++ b/mcomix/mcomix/preferences_dialog.py
@@ -333,6 +333,13 @@ class _PreferencesDialog(Gtk.Dialog):
         page.add_row(Gtk.Label(label=_('Sort archives by:')),
             self._create_archive_sort_by_control())
 
+        page.new_section(_('File detection'))
+
+        page.add_row(self._create_pref_check_button(
+            _('Detect image file(s) by mimetypes'),
+            'check image mimetype',
+            _('Detect image file(s) by mimetypes.')))
+
         page.new_section(_('Extraction and cache'))
 
         page.add_row(Gtk.Label(label=_('Maximum number of concurrent extraction threads:')),
@@ -822,6 +829,9 @@ class _PreferencesDialog(Gtk.Dialog):
             self._window.thumbnailsidebar.toggle_page_numbers_visible()
 
         elif preference in ('animation background', 'animation transform'):
+            self._window.filehandler.refresh_file()
+
+        elif preference in ('check image mimetype',):
             self._window.filehandler.refresh_file()
 
 

--- a/mcomix/mcomix/thumbnail_tools.py
+++ b/mcomix/mcomix/thumbnail_tools.py
@@ -149,7 +149,7 @@ class Thumbnailer(object):
 
                 return pixbuf, tEXt_data
 
-        elif image_tools.is_image_file(filepath):
+        elif image_tools.is_image_file(filepath, check_mimetype=True):
             pixbuf = image_tools.load_pixbuf_size(filepath, self.width, self.height)
             if self.store_on_disk:
                 tEXt_data = self._get_text_data(filepath)


### PR DESCRIPTION
Detect supported image files by reading starting bytes of files, and filename is ignored.
Files in archive is still detected by filename.