### PR TITLE
Add option to ignore extension to sort archives

### DIFF
--- a/mcomix/mcomix/file_provider.py
+++ b/mcomix/mcomix/file_provider.py
@@ -71,11 +71,13 @@ class FileProvider(object):
             yield from os.listdir(root)
 
     @staticmethod
-    def sort_files(files):
+    def sort_files(files, mode=None):
         ''' Sorts a list of C{files} depending on the current preferences.
         The list is sorted in-place. '''
         if prefs['sort by'] == constants.SORT_NAME:
-            tools.alphanumeric_sort(files)
+            tools.alphanumeric_sort(files,
+                                    mode == FileProvider.ARCHIVES and
+                                    prefs['ignore archive file extension'])
         elif prefs['sort by'] == constants.SORT_LAST_MODIFIED:
             # Most recently modified file first
             files.sort(key=lambda filename: os.path.getmtime(filename)*-1)
@@ -143,7 +145,7 @@ class OrderedFileProvider(FileProvider):
                         self.base_dir)
             return []
 
-        FileProvider.sort_files(files)
+        FileProvider.sort_files(files, mode)
         return [fname_map[fpath] for fpath in files]
 
     def next_directory(self):

--- a/mcomix/mcomix/preferences.py
+++ b/mcomix/mcomix/preferences.py
@@ -22,6 +22,7 @@ prefs = {
     'sort order': constants.SORT_ASCENDING,
     'sort archive by': constants.SORT_NAME,  # Files in archives
     'sort archive order': constants.SORT_ASCENDING,
+    'ignore archive file extension': False,
     'bg colour': [0, 0, 0, 0],
     'thumb bg colour': [0, 0, 0, 0],
     'smart bg': False,

--- a/mcomix/mcomix/preferences_dialog.py
+++ b/mcomix/mcomix/preferences_dialog.py
@@ -344,6 +344,11 @@ class _PreferencesDialog(Gtk.Dialog):
         page.add_row(Gtk.Label(label=_('Sort archives by:')),
             self._create_archive_sort_by_control())
 
+        page.add_row(self._create_pref_check_button(
+            _('Ignore file extension to sort archives'),
+            'ignore archive file extension',
+            _('Do not use file extension when sorting archives. This permits to sort x before x.5.')))
+
         page.new_section(_('File detection'))
 
         page.add_row(self._create_pref_check_button(

--- a/mcomix/mcomix/tools.py
+++ b/mcomix/mcomix/tools.py
@@ -20,7 +20,7 @@ def cmp(x,y):
     if x<y:return -1
     return 0
 
-def alphanumeric_sort(filenames):
+def alphanumeric_sort(filenames, ignore_extension=False):
     '''Do an in-place alphanumeric sort of the strings in <filenames>,
     such that for an example "1.jpg", "2.jpg", "10.jpg" is a sorted
     ordering.
@@ -31,7 +31,8 @@ def alphanumeric_sort(filenames):
 
         return 1,s.lower()
 
-    filenames.sort(key=lambda s: list(map(_format_substring, NUMERIC_REGEXP.findall(s))))
+    filenames.sort(key=lambda s: list(map(_format_substring, NUMERIC_REGEXP.findall(
+        os.path.splitext(s)[0] if ignore_extension else s))))
 
 def alphanumeric_compare(s1, s2):
     ''' Compares two strings by their natural order (i.e. 1 before 10)


### PR DESCRIPTION
This fix ordering for some manga that use the following numbering for
chapters: 100, 100.5, 101...

With the option deactivated the order is: 100.5.zip, 100.zip, 101.zip
and 100.zip, 100.5.zip, 101.zip with the option activated.