### PR TITLE
Try to read bookmarks pickled by Python 2

### DIFF
--- a/mcomix/mcomix/bookmark_backend.py
+++ b/mcomix/mcomix/bookmark_backend.py
@@ -6,6 +6,7 @@ from gi.repository import Gtk
 import operator
 import datetime
 import time
+import shutil
 
 from mcomix import constants
 from mcomix import log
@@ -141,8 +142,8 @@ class __BookmarksStore(object):
             try:
                 mtime = os.stat(path).st_mtime
                 with open(path, 'rb') as fd:
-                    version = pickle.load(fd)
-                    packs = pickle.load(fd)
+                    version = pickle.load(fd, encoding='latin1')
+                    packs = pickle.load(fd, encoding='latin1')
 
                     for pack in packs:
                         # Handle old bookmarks without date_added attribute
@@ -155,6 +156,13 @@ class __BookmarksStore(object):
 
             except Exception:
                 log.error(_('! Could not parse bookmarks file %s'), path)
+                backup_path = path + '.bak'
+                if not os.path.exists(backup_path):
+                    log.warning(_('! Backing up bookmarks file to %s'), backup_path)
+                    shutil.copyfile(path, backup_path)
+                else:
+                    log.error(_('! Cannot create backup bookmarks file at %s'), backup_path)
+                    raise
 
         return bookmarks, mtime
 


### PR DESCRIPTION
When a pickle file is saved by Python 2, it can be unreadable from Python 3 if
certain kinds of objects are stored in it, such as non-Unicode strings.  To
reliably unpickle these objects, a fallback string encoding must be supplied to
`pickle.load()`.

It turns out that `datetime` objects, which MComix saves as part of each
bookmark, are serialized as non-Unicode binary strings (using the pickle
format's opcode `SHORT_BINSTRING`).  According to the [Python
documentation][1],

> Using `encoding='latin1'` is required for unpickling NumPy arrays and
> instances of *datetime*, *date* and *time* pickled by Python 2.

This commit does as recommended by the above sentence from the documentation.

Furthermore, this commit makes it so that if MComix fails to unpickle the
bookmarks file, it will back up the existing file before proceeding (because
otherwise it will be overwritten with an empty set of bookmarks later).  If the
backup file cannot be saved, the program will crash to avoid destroying the
user's data.

[1]: https://docs.python.org/3/library/pickle.html#pickle.Unpickler "pickle"

----

This should fix #98.