### PR TITLE
Stop extractor when the threadpool terminates

### DIFF
--- a/mcomix/mcomix/archive_extractor.py
+++ b/mcomix/mcomix/archive_extractor.py
@@ -170,6 +170,8 @@ class Extractor(object):
         log.debug('Extracting from "%s" to "%s": "%s"',
                   self._src, self._dst, '", "'.join(files))
         for name in self._archive.iter_extract(files, self._dst):
+            if self._threadpool.closed:
+                break
             self._extraction_finished(name)
 
     def _extract_file(self, name):

--- a/mcomix/mcomix/archive_extractor.py
+++ b/mcomix/mcomix/archive_extractor.py
@@ -158,7 +158,7 @@ class Extractor(object):
         with self._condition:
             self._files.remove(name)
             self._extracted.add(name)
-            self._condition.notifyAll()
+            self._condition.notify_all()
         self.file_extracted(self, name)
 
     def _extract_all_files(self):

--- a/mcomix/mcomix/worker_thread.py
+++ b/mcomix/mcomix/worker_thread.py
@@ -104,7 +104,7 @@ class WorkerThread(object):
             self._orders_queue.append(order)
             if self._sort_orders:
                 self._orders_queue.sort()
-            self._condition.notifyAll()
+            self._condition.notify_all()
             self._start()
 
     def extend_orders(self, orders_list):
@@ -127,14 +127,14 @@ class WorkerThread(object):
                 return
             if self._sort_orders:
                 self._orders_queue.sort()
-            self._condition.notifyAll()
+            self._condition.notify_all()
             self._start(nb_threads=nb_added)
 
     def stop(self):
         '''Stop the worker threads and flush the orders queue.'''
         self._stop = True
         with self._condition:
-            self._condition.notifyAll()
+            self._condition.notify_all()
         for thread in self._threads:
             thread.join()
         self._threads = []


### PR DESCRIPTION
When opening a large archive, and trying to close mcomix or switch to a different archive, it hangs until the extractor is done.

This makes the extractor periodically check if it should stop.

Another commit renames `notifyAll` to Python 3's `notify_all`. The old function name is aliased, but undocumented.