### PR TITLE
fix comicthumb not generate thumbnail

### DIFF
--- a/mcomix/comicthumb.py
+++ b/mcomix/comicthumb.py
@@ -43,7 +43,7 @@ def main():
     parser.add_argument('size',nargs='?',default=THUMB_SIZE,metavar='SIZE',
                         help='size of thumbnail (default: {})'.format(THUMB_SIZE))
     ns=parser.parse_args()
-    in_path=abspath(ns.infile)
+    in_path=ns.infile
     out_path=abspath(ns.outfile)
     if in_path.startswith(URL_PREFIX):
         in_path=unquote(in_path[len(URL_PREFIX):])


### PR DESCRIPTION
i'm using arch on i3 with thunar.

with abspath in_path become `/home/xtrymind/MEGAsync Downloads/file:/home/xtrymind` thus it failed since it not correct path.

second way to fix this is change URI with filename
`Exec=comicthumb %i %o %s`

both work for me