### PR TITLE
Add more resampling algorithms (from PIL), like Lanczos

### DIFF
--- a/mcomix/mcomix/preferences.py
+++ b/mcomix/mcomix/preferences.py
@@ -100,6 +100,7 @@ prefs = {
     'max extract threads': 1,
     'wrap mouse scroll': False,
     'scaling quality': 2,  # GdkPixbuf.InterpType.BILINEAR
+    'pil scaling filter': -1, # Use a PIL filter (just lanczos for now) in main viewing area. -1 to just use GdkPixbuf
     'escape quits': False,
     'fit to size mode': constants.ZOOM_MODE_HEIGHT,
     'fit to size px': 1800,

--- a/mcomix/mcomix/preferences_dialog.py
+++ b/mcomix/mcomix/preferences_dialog.py
@@ -305,7 +305,9 @@ class _PreferencesDialog(Gtk.Dialog):
         page.add_row(Gtk.Label(label=_('Scaling mode')),
             self._create_scaling_quality_combobox())
 
-        page.add_row(Gtk.Label(label=_('High-quality scaling for main area')),
+        page.new_section(_('Advanced filters'))
+
+        page.add_row(Gtk.Label(label=_('Apply a high-quality scaling filter (main viewing area only):')),
             self._create_pil_scaling_filter_combobox())
 
         return page
@@ -689,14 +691,14 @@ class _PreferencesDialog(Gtk.Dialog):
     def _create_pil_scaling_filter_combobox(self):
         ''' Creates combo box for PIL filter to scale with in main view '''
         items = (
-                (_('Off'), -1), # -1 defers to 'scaling quality'
+                (_('None'), -1), # -1 defers to 'scaling quality'
                 (_('Lanczos'), int(PIL.Image.LANCZOS))) # PIL type 1.
 
         selection = prefs['pil scaling filter']
 
         box = self._create_combobox(items, selection, self._pil_scaling_filter_changed_cb)
         box.set_tooltip_text(
-            _('If set, a scaling filter from PIL will be preferred over the "scaling quality" selection, in the main view only. This will impact performance.'))
+            _('If set, a scaling filter from PIL will be used instead of the "scaling quality" selection in the main view only. This will impact performance and memory usage.'))
 
         return box
 

--- a/mcomix/mcomix/preferences_dialog.py
+++ b/mcomix/mcomix/preferences_dialog.py
@@ -5,6 +5,8 @@
 import sys
 
 from gi.repository import Gdk, GdkPixbuf, Gtk, GObject
+import PIL
+from PIL import Image # for PIL interpolation prefs
 
 from mcomix.languages import languages
 from mcomix.preferences import prefs
@@ -660,7 +662,11 @@ class _PreferencesDialog(Gtk.Dialog):
         items = (
                 (_('Normal (fast)'), int(GdkPixbuf.InterpType.TILES)),
                 (_('Bilinear'), int(GdkPixbuf.InterpType.BILINEAR)),
-                (_('Hyperbolic (slow)'), int(GdkPixbuf.InterpType.HYPER)))
+                (_('Hyperbolic (slow)'), int(GdkPixbuf.InterpType.HYPER)),
+                (_('Lanczos (slow)'), int(GdkPixbuf.InterpType.HYPER) + int(PIL.Image.LANCZOS)), # PIL type 1. Type 0 is 'nearest-neighbor,' which is in GDK Pixbuf already.
+                (_('Bicubic (slow)'), int(GdkPixbuf.InterpType.HYPER) + int(PIL.Image.BICUBIC)), # PIL type 3. PIL Type 2 is bilinear, which we already have from GDK Pixbuf, so we skip it here.
+                (_('Box'), int(GdkPixbuf.InterpType.HYPER) + int(PIL.Image.BOX)), # PIL type 4. When upscaling, is like NEAREST (type 0 in both PIL and PixBuf). Good for pixel art enlargement.
+                (_('Hamming (slow)'), int(GdkPixbuf.InterpType.HYPER) + int(PIL.Image.HAMMING))) # PIL type 5.
 
         selection = prefs['scaling quality']
 


### PR DESCRIPTION
PIL contains several resampling algorithms that are not a part of GDK PixBuf (the only options currently provided in MComix are for the PixBuf resampling types). Since MComix is already using PIL, these resampling options can be added at minimal extra cost; performance is likely slightly worse, on account of having to convert the PixBuf to a PIL `Image` and then back again when the resampling is finished, but the quality of a couple of the resamplers (particularly `LANCZOS` and `HAMMING`) is subjectively superior (definitely sharper) when compared to that of `Gdk.InterpType.HYPER`/`BILINEAR`/`TILE`.

Images with alpha channels are resampled in RGBA and then composited using same PixBuf methods as before, and the conversions to and from PIL are skipped if the scaling type is set to one of the options already handled by Gdk itself.

I think the logic to handle this is sound, but it could probably be made more future-proof if the `scaling type` preference were changed from an int value to a string or some other type. Since this could break existing config files, I have left it as an integer and used a little extra logic to add the PIL types after the PixBuf ones.

Let me know if there's something you want changed; I'd be happy to do it.