### PR TITLE
ignore missing 'scaling quality' in old preferences

### DIFF
--- a/mcomix/mcomix/preferences.py
+++ b/mcomix/mcomix/preferences.py
@@ -144,7 +144,7 @@ def check_old_preferences(saved_prefs):
             upgrade_tools.fileinfo_conv(
                 fileinfo_pickle, constants.FILEINFO_JSON_PATH)
 
-    if saved_prefs['scaling quality']==3:
+    if saved_prefs.get('scaling quality')==3:
         # deprecate GdkPixbuf.InterpType.HYPER with GdkPixbuf.InterpType.BILINEAR
         saved_prefs['scaling quality']=2
 


### PR DESCRIPTION
Fixes the following problem, which occurs in some configuration circumstances:
```
Traceback (most recent call last):
  File "/nix/store/k4bvykaynrhhm8zp6y4c0ib3qa7ikcjg-mcomix3-1.2.1+gc5afd370/bin/.mcomixstarter.py-wrapped", line 34, in <module>
    mcomix.run.run()
  File "/nix/store/k4bvykaynrhhm8zp6y4c0ib3qa7ikcjg-mcomix3-1.2.1+gc5afd370/bin/mcomix/run.py", line 92, in run
    preferences.read_preferences_file()
  File "/nix/store/k4bvykaynrhhm8zp6y4c0ib3qa7ikcjg-mcomix3-1.2.1+gc5afd370/bin/mcomix/preferences.py", line 170, in read_preferences_file
    check_old_preferences(saved_prefs)
  File "/nix/store/k4bvykaynrhhm8zp6y4c0ib3qa7ikcjg-mcomix3-1.2.1+gc5afd370/bin/mcomix/preferences.py", line 147, in check_old_preferences
    if saved_prefs['scaling quality']==3:
KeyError: 'scaling quality'
```