### PR TITLE
Fix Save As

### DIFF
--- a/mcomix/mcomix/main.py
+++ b/mcomix/mcomix/main.py
@@ -1036,7 +1036,7 @@ class MainWindow(Gtk.Window):
                                 Gtk.STOCK_CANCEL, Gtk.ResponseType.REJECT)
         save_dialog.set_transient_for(self)
         save_dialog.set_do_overwrite_confirmation(True)
-        save_dialog.set_current_name(suggested_name.encode('utf-8'))
+        save_dialog.set_current_name(suggested_name)
 
         if save_dialog.run() == Gtk.ResponseType.ACCEPT and save_dialog.get_filename():
             shutil.copy(self.imagehandler.get_path_to_page(),


### PR DESCRIPTION
Remove encode that currently breaks the extract_page function due to "TypeError: Must be string, not bytes" when setting the name in save_dialog