### PR TITLE
Implement preferences for opening the first file in a previous archive/directory

### DIFF
--- a/mcomix/mcomix/file_handler.py
+++ b/mcomix/mcomix/file_handler.py
@@ -482,7 +482,10 @@ class FileHandler(object):
             for path in reversed(files[:current_index]):
                 if archive_tools.archive_mime_type(path) is not None:
                     self._close()
-                    self.open_file(path, -1, keep_fileprovider=True)
+                    if prefs['open first file in prev archive']:
+                        self.open_file(path, 0, keep_fileprovider=True)
+                    else:
+                        self.open_file(path, -1, keep_fileprovider=True)
                     return True
 
         return False
@@ -535,10 +538,17 @@ class FileHandler(object):
         files = self._file_provider.list_files(listmode)
         self._close()
         if len(files) > 0:
-            path = files[-1]
+            if prefs['open first file in prev directory']:
+                path = files[0]
+            else:
+                path = files[-1]
         else:
             path = self._file_provider.get_directory()
-        self.open_file(path, -1, keep_fileprovider=True)
+        
+        if prefs['open first file in prev directory']:
+            self.open_file(path, 0, keep_fileprovider=True)
+        else:
+            self.open_file(path, -1, keep_fileprovider=True)
         return True
 
     def file_is_available(self, filepath):

--- a/mcomix/mcomix/preferences.py
+++ b/mcomix/mcomix/preferences.py
@@ -20,6 +20,8 @@ prefs = {
     'number of key presses before page turn': 3,
     'auto open next archive': True,
     'auto open next directory': True,
+    'open first file in prev archive': False,
+    'open first file in prev directory': False,
     'dive into subdir': False,
     'sort by': constants.SORT_NAME,  # Normal files obtained by directory listing
     'sort order': constants.SORT_ASCENDING,

--- a/mcomix/mcomix/preferences_dialog.py
+++ b/mcomix/mcomix/preferences_dialog.py
@@ -195,6 +195,16 @@ class _PreferencesDialog(Gtk.Dialog):
             _('Automatically open next directory'),
             'auto open next directory',
             _('Automatically open the first file in the next sibling directory when flipping past the last page of the last file in a directory, or the previous directory when flipping past the first page of the first file.')))
+        
+        page.add_row(self._create_pref_check_button(
+            _('Open first file when navigating to previous archive'), 
+            'open first file in prev archive',
+            _('Automatically open the first file of the previous archive when navigating to it, instead of opening the last file of the previous archive.')))
+        
+        page.add_row(self._create_pref_check_button(
+            _('Open first file when navigating to previous directory'), 
+            'open first file in prev directory',
+            _('Automatically open the first file of the previous directory when navigating to it, instead of opening the last file of the previous directory.')))
 
         page.add_row(self._create_pref_check_button(
             _('Dive into subdirectories (restart required)'),


### PR DESCRIPTION
Currently, navigating to the previous archive/directory (whether through automatically opening it or through a shortcut) always lands the user on the last file of that archive/directory. This commit would add a couple options (one for prev archive, one for prev directory) that would enable opening the first file of that archive/directory instead. Overall, this would make it more intuitive to traverse across the initial images (covers) of archives/directories not only forward, but now also backwards.