### PR TITLE
Fix certain case with first file in archive/directory preferences

### DIFF
--- a/mcomix/mcomix/file_handler.py
+++ b/mcomix/mcomix/file_handler.py
@@ -539,9 +539,12 @@ class FileHandler(object):
             path = files[prefs['open first file in prev directory']-1]
         else:
             path = self._file_provider.get_directory()
-
-        self.open_file(path, prefs['open first file in prev directory']-1,
-                       keep_fileprovider=True)
+        
+        if prefs['open first file in prev archive']:
+            self.open_file(path, 0, keep_fileprovider=True)
+        else:
+            self.open_file(path, prefs['open first file in prev directory']-1,
+                            keep_fileprovider=True)
         return True
 
     def file_is_available(self, filepath):


### PR DESCRIPTION
Let's say you have a directory structure like this:

![tree](https://user-images.githubusercontent.com/76411090/102905801-ab27b000-4441-11eb-9bdf-7f7b7f135259.png)

If the user had 'first file in prev archive' enabled but 'first file in prev directory' disabled, navigating from comic2/volume1.zip to comic1/volume2.zip would open the last file in comic/volume2.zip, which is undesirable with the enabled preference. This commit should fix that case.