### PR TITLE
Fixed RTL language layout

### DIFF
--- a/mcomix/mcomix/run.py
+++ b/mcomix/mcomix/run.py
@@ -195,7 +195,7 @@ def run():
 
     # Some languages require a RTL layout
     if preferences.prefs['language'] in ('he', 'fa'):
-        Gtk.widget_set_default_direction(Gtk.TextDirection.RTL)
+        Gtk.Widget.set_default_direction(Gtk.TextDirection.RTL)
 
     Gdk.set_program_class(constants.APPNAME)
 


### PR DESCRIPTION
An old syntax thats is not supported by PyGObject was used to set default text direction as RTL in RTL language.
Updated based on the current docs for PyGObject 
found here https://lazka.github.io/pgi-docs/#Gtk-3.0/classes/Widget.html#Gtk.Widget.set_direction
Tested on archlinux.

fixes issue #135