### PR TITLE
Add preference allowing user to disable click to flip (pnppl's sourceforge patch)

### DIFF
--- a/mcomix/mcomix/event.py
+++ b/mcomix/mcomix/event.py
@@ -416,7 +416,8 @@ class EventHandler(object):
 
             if event.x_root == self._pressed_pointer_pos_x and \
                event.y_root == self._pressed_pointer_pos_y and \
-               not self._window.was_out_of_focus:
+               not self._window.was_out_of_focus and \
+               prefs['flip with click']:
 
                 # right to next, left to previous, no matter the double page mode
                 direction = 1 if event.x > widget.get_property('width') // 2 else -1

--- a/mcomix/mcomix/preferences.py
+++ b/mcomix/mcomix/preferences.py
@@ -57,6 +57,7 @@ prefs = {
     'invert smart scroll': False,
     'smart scroll percentage': 0.5,
     'flip with wheel': True,
+    'flip with click': True,
     'store recent file info': True,
     'hide all': False,
     'hide all in fullscreen': True,

--- a/mcomix/mcomix/preferences_dialog.py
+++ b/mcomix/mcomix/preferences_dialog.py
@@ -195,6 +195,11 @@ class _PreferencesDialog(Gtk.Dialog):
             _('Flip pages when scrolling "off the page" with the scroll wheel or with the arrow keys. It takes n consecutive "steps" with the scroll wheel or the arrow keys for the pages to be flipped.')))
 
         page.add_row(self._create_pref_check_button(
+            _('Flip pages with left-click'),
+            'flip with click',
+            _('Click on the page to turn to the next one.')))
+
+        page.add_row(self._create_pref_check_button(
             _('Automatically open the next archive'),
             'auto open next archive',
             _('Automatically open the next archive in the directory when flipping past the last page, or the previous archive when flipping past the first page.')))


### PR DESCRIPTION
mcomix's click-to-flip behavior can primarily be annoying when clicking the window to bring it into focus. Long ago I looked into seeing if an option for disabling this functionality was ever suggested, and I noticed there was a patch leftover on mcomix's old sourceforge page. I've used said patch created by sourceforge user pnppl ( https://sourceforge.net/p/mcomix/patches/53/ ) for a while now, and it works fine.

The patch adds a setting for the click to flip functionality, defaulting to enabled.