### PR TITLE
Stop pdf extraction when program terminates

### DIFF
--- a/mcomix/mcomix/archive/pdf_external.py
+++ b/mcomix/mcomix/archive/pdf_external.py
@@ -67,7 +67,14 @@ class PdfArchive(archive_base.BaseArchive):
         # Render...
         cmd = _mudraw_exec + ['-r', str(max_dpi), '-o', destination_path, '--', self.archive, str(page_num)]
         log.debug('rendering %s: %s', filename, ' '.join(cmd))
-        process.call(cmd)
+        with process.popen(cmd) as proc:
+            while proc.poll() is None:
+                try:
+                    proc.wait(0.25)
+                except:
+                    pass
+                if self._terminator_func and self._terminator_func():
+                    proc.terminate()
         return destination_path
 
     @staticmethod

--- a/mcomix/mcomix/archive_extractor.py
+++ b/mcomix/mcomix/archive_extractor.py
@@ -41,7 +41,8 @@ class Extractor(object):
         self._files = []
         self._extracted = set()
         self._archive = archive_tools.get_recursive_archive_handler(
-            src, type=type, prefix='mcomix.extractor.')
+            src, type=type, prefix='mcomix.extractor.',
+            terminator_func=lambda: self._threadpool.closed)
         if self._archive is None:
             msg = _('Non-supported archive format: %s') % os.path.basename(src)
             log.warning(msg)
@@ -179,6 +180,8 @@ class Extractor(object):
         '''
         log.debug('Extracting from "%s" to "%s": "%s"',
                   self._src, self._dst, name)
+        if self._threadpool.closed:
+            return name
         self._archive.extract(name)
         return name
 

--- a/mcomix/mcomix/archive_tools.py
+++ b/mcomix/mcomix/archive_tools.py
@@ -207,7 +207,7 @@ def get_archive_info(path):
 
         return (mime, num_pages, size)
 
-def get_archive_handler(path, type=None):
+def get_archive_handler(path, type=None, terminator_func=None):
     ''' Returns a fitting extractor handler for the archive passed
     in <path> (with optional mime type <type>. Returns None if no matching
     extractor was found.
@@ -221,13 +221,15 @@ def get_archive_handler(path, type=None):
     if handler is None:
         return None
 
-    return handler(path)
+    archive = handler(path)
+    archive._terminator_func = terminator_func
+    return archive
 
-def get_recursive_archive_handler(path, type=None, **kwargs):
+def get_recursive_archive_handler(path, type=None, terminator_func=None, **kwargs):
     ''' Same as <get_archive_handler> but the handler will transparently handle
     archives within archives.
     '''
-    archive = get_archive_handler(path, type=type)
+    archive = get_archive_handler(path, type, terminator_func)
     if archive is None:
         return None
     # XXX: Deferred import to avoid circular dependency


### PR DESCRIPTION
PDF pages can take several seconds to extract. If I attempt to terminate mcomix while extraction is taking place, I have to wait for all the current queued page extractions to complete. This makes the program seem unresposive, and my OS even suggests to force-terminate it.

This patch uses a similar approach as #110, passing a program termination checker into the PDF archive class, and checks it periodically while the PDF extraction process is running. I pass it after the archive is created, so it doesn't interfere with any constructor signatures of existing archive subclasses who don't use the termination check.

It also makes already-queued individual page extractions check the status before the start and do nothing. Maybe that part isn't required.

Two questions:
* By returning successfully and doing nothing I'm causing malformed images to be cached?
* Should the terminator func be passed as an argument to `Archive.extract()` instead of as a class property?