### PR TITLE
Added preference for navigation behaviour depepending on mouse pos

### DIFF
--- a/mcomix/mcomix/event.py
+++ b/mcomix/mcomix/event.py
@@ -425,8 +425,16 @@ class EventHandler(object):
             if (self._pressed_pointer_pos_x, self._pressed_pointer_pos_y) == \
                (event.x_root, event.y_root):
 
-                # right to next, left to previous, no matter the double page mode
-                direction = 1 if event.x > widget.get_property('width') // 2 else -1
+                # only when "mouse position affects navigation" is set consider we
+                # consider mouse position
+                direction = 1
+
+                if prefs['mouse position affects navigation']:
+                    # right to next, left to previous, no matter the double page mode
+                    if event.x > widget.get_property('width') // 2 :
+                        direction = 1
+                    else:
+                        direction = -1
 
                 # if in manga mode, left to next, right to previous
                 if self._window.is_manga_mode:

--- a/mcomix/mcomix/messages/ru/LC_MESSAGES/mcomix.po
+++ b/mcomix/mcomix/messages/ru/LC_MESSAGES/mcomix.po
@@ -3050,6 +3050,22 @@ msgstr ""
 msgid "Automatically scan for new books when library is _opened"
 msgstr "Автоматически добавить книги в эту коллекцию."
 
+#: mcomix/mcomix/preferences_dialog.py:193
+msgid "Consider mouse position when going to next/prev page"
+msgstr "Учитывать положение курсора мыши при переходе на предыдущую/следующую страницу"
+
+#: mcomix/mcomix/preferences_dialog.py:195
+msgid "With this preference set, the mouse position affects the "
+msgstr "Если включено, то позиция курсора мыши влияет "
+
+#: mcomix/mcomix/preferences_dialog.py:196
+msgid "way how navigation works. If set, clicking on left side of "
+msgstr "на то как работает навигация. При включении, клик на левой стороне"
+
+#: mcomix/mcomix/preferences_dialog.py:197
+msgid "the screen leads to the previos page, not to the next one."
+msgstr "экрана перемещает на предыдущее изображение, а не на следующее."
+
 #~ msgid "Installed GTK+ version is: %s"
 #~ msgstr "Установленная версия GTK+ : %s"
 

--- a/mcomix/mcomix/preferences.py
+++ b/mcomix/mcomix/preferences.py
@@ -54,6 +54,7 @@ prefs = {
     'slideshow can go to next archive': True,
     'number of pixels to scroll per slideshow event': 50,
     'smart scroll': True,
+    'mouse position affects navigation': True,
     'invert smart scroll': False,
     'smart scroll percentage': 0.5,
     'flip with wheel': True,

--- a/mcomix/mcomix/preferences_dialog.py
+++ b/mcomix/mcomix/preferences_dialog.py
@@ -190,6 +190,13 @@ class _PreferencesDialog(Gtk.Dialog):
               'try to follow the natural reading order of the comic book.')))
 
         page.add_row(self._create_pref_check_button(
+            _('Consider mouse position when going to next/prev page'),
+            'mouse position affects navigation',
+            _('With this preference set, the mouse position affects the '
+              'way how navigation works. If set, clicking on left side of '
+              'the screen leads to the previos page, not to the next one.')))
+
+        page.add_row(self._create_pref_check_button(
             _('Flip pages when scrolling off the edges of the page'),
             'flip with wheel',
             _('Flip pages when scrolling "off the page" with the scroll wheel or with the arrow keys. It takes n consecutive "steps" with the scroll wheel or the arrow keys for the pages to be flipped.')))


### PR DESCRIPTION
In version shipped with previous Debian the behaviour was different - clicking everywhere on the screen moved you to the next page. New behaviour can confuse when you don't see where the mouse cursor actually is in fullscreen mode.