### PR TITLE
openwith cwd fix

### DIFF
--- a/mcomix/mcomix/openwith.py
+++ b/mcomix/mcomix/openwith.py
@@ -70,21 +70,18 @@ class OpenWithCommand(object):
                             self.get_label())
             return
 
-        current_dir = os.getcwd()
         try:
+            workdir = None
             if self.is_valid_workdir(window):
                 workdir = self.parse(window, text=self.get_cwd())[0]
-                os.chdir(workdir)
 
             args = self.parse(window)
-            process.call_thread(args)
+            process.call_thread(args, cwd=workdir)
 
         except Exception as e:
             text = _('Could not run command %(cmdlabel)s: %(exception)s') % \
                 {'cmdlabel': self.get_label(), 'exception': str(e)}
             window.osd.show(text)
-        finally:
-            os.chdir(current_dir)
 
     def is_executable(self, window):
         ''' Check if a name is executable. This name can be either

--- a/mcomix/mcomix/process.py
+++ b/mcomix/mcomix/process.py
@@ -49,11 +49,12 @@ def popen(args, stdin=NULL, stdout=PIPE, stderr=NULL, universal_newlines=False):
                             universal_newlines=universal_newlines,
                             creationflags=_get_creationflags())
 
-def call_thread(args):
+def call_thread(args, cwd=None):
     # call command in thread, so drop std* and set no buffer
     params=dict(
         stdin=NULL,stdout=NULL,stderr=NULL,
-        bufsize=0,creationflags=_get_creationflags()
+        bufsize=0,creationflags=_get_creationflags(),
+        cwd=cwd
     )
     thread=Thread(target=subprocess.call,
                   args=(args,),kwargs=params,daemon=True)


### PR DESCRIPTION
The way the cwd was working didn't work in my setup. So I changed it to use the cwd kwarg of subprocess.
Additionally, rarely, mcomix would have pathing hiccups when I ran an `open with` command with a defined cwd and mcomix was executing other things with relative paths