### PR TITLE
Fix crashing when get_bg_color only returns rgb

### DIFF
--- a/mcomix/mcomix/lens.py
+++ b/mcomix/mcomix/lens.py
@@ -173,7 +173,7 @@ class MagnifyingLens(object):
                                       has_alpha=True, bits_per_sample=8,
                                       width=prefs['lens size'],
                                       height=prefs['lens size'])
-        r,g,b,a = [int(p*255) for p in self._window.get_bg_color()]
+        r,g,b,*a = [int(p*255) for p in self._window.get_bg_color()]
         canvas.fill(image_tools.pixel2int([r,g,b,0xff]))
         cb = self._window.layout.get_content_boxes()
         source_pixbufs = self._window.imagehandler.get_pixbufs(len(cb))


### PR DESCRIPTION
When it returns rgb, the `a` is missing for unpacking which can cause a crash.
This makes the a (alpha) optional.

fixes #139