### PR TITLE
Improve horizontal scrolling behavior

### DIFF
--- a/mcomix/mcomix/event.py
+++ b/mcomix/mcomix/event.py
@@ -371,16 +371,10 @@ class EventHandler(object):
                 self._scroll_with_flipping(0, prefs['number of pixels to scroll per mouse wheel event'])
 
         elif direction == Gdk.ScrollDirection.RIGHT:
-            if not self._window.is_manga_mode:
-                self._window.flip_page(+1)
-            else:
-                self._previous_page_with_protection()
+            self._scroll_with_flipping(prefs['number of pixels to scroll per mouse wheel event'], 0)
 
         elif direction == Gdk.ScrollDirection.LEFT:
-            if not self._window.is_manga_mode:
-                self._previous_page_with_protection()
-            else:
-                self._window.flip_page(+1)
+            self._scroll_with_flipping(-prefs['number of pixels to scroll per mouse wheel event'], 0)
 
     def mouse_press_event(self, widget, event):
         '''Handle mouse click events on the main layout area.'''


### PR DESCRIPTION
Currently, horizontal scroll-wheel events are handled oddly. The scroll wheel can never be used to scroll horizontally, even when a horizontal scrollbar is present (contradicting the behavior described in the `scroll_wheel_event` docstring), and both scroll protection and the `flip with wheel` preference are ignored if the page would be turned forwards.

This patch permits horizontal scrolling when applicable and respects protection (and therefore `flip with wheel`) in all directions. `_scroll_with_flipping` already handles manga mode, so there's no need for this logic in `scroll_wheel_event`.